### PR TITLE
Patch for Slack Webhook Integration

### DIFF
--- a/slack/0.1.0/README.md
+++ b/slack/0.1.0/README.md
@@ -15,7 +15,7 @@ This integration shows you how to send notifications to Slack leveraging [Keptn'
 [WATCH THIS VIDEO TUTORIAL](https://www.youtube.com/watch?v=0vJS7ecayGw&t=7s) to see this in action.
 
 Here is a quick overview of how those messages in Slack can look like (message content and format can be customized):
-![](https://github.com/keptn-sandbox/artifacthub/blob/b1fddd0bd4b7f336809fbf1024c35c6f43943115/slack/0.1.0/images/slack-notifications.png)
+![](https://raw.githubusercontent.com/keptn-sandbox/artifacthub/main/slack/0.1.0/images/slack-notifications.png)
 
 <!-- Prerequisites describe the way of creating the Webhook at the target tooling. -->
 
@@ -62,7 +62,8 @@ bridgeUrl: https://your.keptn.URL
 ```
 
 For reference, here is a screenshot of that secret:
-![](https://github.com/keptn-sandbox/artifacthub/blob/b1fddd0bd4b7f336809fbf1024c35c6f43943115/slack/0.1.0/images/secret-configuration.png)
+
+![](https://raw.githubusercontent.com/keptn-sandbox/artifacthub/main/slack/0.1.0/images/secret-configuration.png)
 
 ### Step 2: Subscribe to a Keptn event to push notifications to Slack
 
@@ -109,7 +110,7 @@ To create a webhook integration, a subscription needs to be created:
 * Finally, click **Create subscription** to save and enable the webhook for your Slack integration.
 
 * Here is a screenshot for your reference:
-![](https://github.com/keptn-sandbox/artifacthub/blob/b1fddd0bd4b7f336809fbf1024c35c6f43943115/slack/0.1.0/images/evaluation-finished-subscription.png)
+![](https://raw.githubusercontent.com/keptn-sandbox/artifacthub/main/slack/0.1.0/images/evaluation-finished-subscription.png)
 
 **Example 2: Deployment Finished Notifications**
 

--- a/slack/0.1.0/artifacthub-pkg.yml
+++ b/slack/0.1.0/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
 # Artifact Hub package metadata file
 # https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml
 version: 0.1.0
-name: slack-webhook
+name: slack
 displayName: Slack Webhook Integration
 createdAt: 2021-11-17T00:00:00Z
 description: Sending notifications to Slack for all sorts of Keptn events such as deployment, test, or evaluation finished. This integration leverages Keptn's webhook-service.
@@ -23,5 +23,5 @@ recommendations:
   - url: https://artifacthub.io/packages/helm/keptn/keptn
 annotations:
   keptn/kind: "notification"
-  keptn/org: "sandbox"
-  keptn/version: ">=0.10.x"
+  keptn/org: "keptn"
+  keptn/version: "0.10.x"


### PR DESCRIPTION
- [x] Fixed broken images
- [x] Naming of folder and integration
- [x] Set keptn/org properly: `keptn/org = keptn`
- [x] keptn/version: "0.10.x"


Signed-off-by: Johannes <johannes.braeuer@dynatrace.com>